### PR TITLE
サイドナビゲーションを神戸市仕様に

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -147,51 +147,52 @@ export default Vue.extend({
         {
           icon: 'CovidIcon',
           title: this.$t('新型コロナウイルス感染症が心配なときに'),
-          link: this.localePath('/flow'),
+          link: this.localePath('/flow')
+        },
+        {
+          icon: 'mdi-shield-alert',
+          title: this.$t('感染症対策について'),
+          link: this.localePath('/guide')
+        },
+        {
+          title: this.$t('神戸市電話相談窓口'),
+          link: this.localePath('/contacts')
+        },
+        {
+          title: this.$t('市長からのメッセージ'),
+          link:
+            'https://www.city.kobe.lg.jp/a57337/kenko/health/corona_shichokoment2.html',
           divider: true
         },
         {
           icon: 'ParentIcon',
           title: this.$t('お子様をお持ちの皆様へ'),
-          link: this.localePath('/parent')
+          link: 'https://www.city.kobe.lg.jp/a57337/kenko/coc.html'
         },
         {
           icon: 'mdi-account-multiple',
-          title: this.$t('都民の皆様へ'),
-          link: 'https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html'
+          title: this.$t('市民の皆様へ'),
+          link:
+            'https://www.city.kobe.lg.jp/a73576/kenko/health/infection/protection/coronavirus.html'
         },
         {
           icon: 'mdi-domain',
-          title: this.$t('企業の皆様・はたらく皆様へ'),
-          link: this.localePath('/worker'),
+          title: this.$t('企業の皆さま・働く皆さまへ'),
+          link:
+            'https://www.city.kobe.lg.jp/a31812/coronavsupportsforbusiness.html',
           divider: true
         },
         {
-          title: this.$t('神戸市新型コロナウイルス感染症対策本部報'),
-          link:
-            'https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html'
-        },
-        {
-          title: this.$t('神戸市主催等 中止又は延期するイベント等'),
-          link:
-            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event00.html'
-        },
-        {
-          title: this.$t('知事からのメッセージ'),
-          link:
-            'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
+          title: this.$t('神戸市主催など中止または延期するイベント'),
+          link: 'https://www.city.kobe.lg.jp/a57337/kenko/eventtyushi.html'
         },
         {
           title: this.$t('当サイトについて'),
           link: this.localePath('/about')
         },
         {
-          title: this.$t('お問い合わせ先一覧'),
-          link: this.localePath('/contacts')
-        },
-        {
           title: this.$t('神戸市公式ホームページ'),
-          link: 'https://www.metro.tokyo.lg.jp/'
+          link: 'https://www.city.kobe.lg.jp/'
         }
       ]
     }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2 

## 📝 関連する issue / Related Issues
- #10 

## ⛏ 変更内容 / Details of Changes
- サイドナビゲーションのリンク等を神戸市のものに変更
- 「感染症対策について」には新規ページとして `/guide` を割り当て（ページは未作成）

## WIP
- [x] アイテムのアイコンの有無やその内容について
  - 「感染症対策について」はとりあえず `mdi-shield-alert` を割り当てた
  - 東京都版と順序が変わるのでアイコンの有無の統一性が変化している
  - 本PR提出時点のスクリーンショットは以下のとおり
    ![image](https://user-images.githubusercontent.com/34566290/77731625-98b14f00-7046-11ea-9737-8315821c89ac.png)
- [x] `ja.json` も同時に変更するかどうか cf. #10 
  - ある程度目処が立ったら一括で変更