### PR TITLE
「市内の最新感染動向」の前に「神戸市」を追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -143,7 +143,7 @@ export default Vue.extend({
       return [
         {
           icon: 'mdi-chart-timeline-variant',
-          title: this.$t('市内の最新感染動向'),
+          title: this.$t('神戸市市内の最新感染動向'),
           link: this.localePath('/')
         },
         {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
       Data,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
-        title: this.$t('市内の最新感染動向')
+        title: this.$t('神戸市市内の最新感染動向')
       },
       newsItems: News.newsItems
     }
@@ -110,7 +110,7 @@ export default Vue.extend({
   },
   head(): MetaInfo {
     return {
-      title: this.$t('市内の最新感染動向') as string
+      title: this.$t('神戸市市内の最新感染動向') as string
     }
   }
 })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #34

## ⛏ 変更内容 / Details of Changes
- `/index` ページとSideNavigationの「市内の最新感染動向」の前に「神戸市」を追加
