### PR TITLE
flowページの電話窓口を神戸市仕様に

### DIFF
--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -17,46 +17,6 @@
             </span>
           </div>
         </div>
-      </div>
-
-      <div :class="$style.AdvisoryContents">
-        <div class="py-8">
-          <div :class="$style.AdvisoryContentsTitle2">
-            {{ $t('平日（日中）') }}
-          </div>
-          <div
-            :class="[
-              $style.AdvisoryLink,
-              $style.AdvisoryBlockCentering,
-              'mt-4'
-            ]"
-          >
-            <a
-              href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <span>{{ $t('各保健所の電話番号は福祉保健局HPへ') }}</span>
-              <v-icon size="18">
-                mdi-open-in-new
-              </v-icon>
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <div :class="$style.AdvisoryContents">
-        <div class="pt-8">
-          <div :class="$style.AdvisoryContentsTitle2">
-            {{ $t('平日（夜間）') }}
-          </div>
-          <span>{{ $t('午後5時から翌朝午前9時') }}</span>
-        </div>
-        <div class="mt-1">
-          <span :class="$style.AdvisoryContentsSubTitle">
-            {{ $t('土日祝 終日') }}
-          </span>
-        </div>
         <div
           :class="[
             $style.AdvisoryTelephoneArea,
@@ -64,18 +24,15 @@
             'mt-1'
           ]"
         >
-          <a :class="$style.AdvisoryTelephone" href="tel:0353204592">
+          <a :class="$style.AdvisoryTelephone" href="tel:0783226829">
             <img
               :class="$style.AdvisoryTelephoneIcon"
               src="/flow/phone-24px.svg"
               aria-hidden="true"
               :alt="$t('電話番号')"
             />
-            03-5320-4592
+            078-322-6829
           </a>
-        </div>
-        <div v-if="!['ja', 'ja-basic'].includes($i18n.locale)" class="pt-8">
-          <span>{{ $t('ひまわり') }}</span>
         </div>
       </div>
     </div>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -51,21 +51,21 @@
 
     <div :class="[$style.SubtleBox, $style.Box2, $style.Center]">
       <div :class="$style.LargerText">
-        {{ $t('新型コロナコールセンター') }}
+        {{ $t('新型コロナ専用健康相談窓口') }}
       </div>
       <div :class="$style.SmallerText">
-        {{ $t('午前9時から午後9時（土日祝含む）') }}
+        {{ $t('24時間対応（土日祝含む）') }}
       </div>
 
       <div :class="$style.Tel">
-        <a :class="$style.TelLink" href="tel:0570550571">
+        <a :class="$style.TelLink" href="tel:0783226250">
           <img
             :class="$style.TelLinkIcon"
             src="/flow/phone-24px.svg"
             aria-hidden="true"
             :alt="$t('電話番号')"
           />
-          0570-550571
+          078-322-6250
         </a>
       </div>
     </div>

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -9,58 +9,12 @@
     <p :class="[$style.open, $style.fzMedium]">
       <span>{{ $t('24時間対応') }}</span>
     </p>
-    <dl>
-      <div :class="$style.daytime">
-        <dt :class="[$style.title, $style.fzMedium]">
-          {{ $t('平日（日中）') }}
-        </dt>
-        <dd :class="$style.link">
-          <a
-            href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {{ $t('各保健所の電話番号は福祉保健局HPへ') }}
-            <v-icon size="16">
-              mdi-open-in-new
-            </v-icon>
-          </a>
-        </dd>
-      </div>
-      <div>
-        <dt>
-          <ul :class="[$style.night]">
-            <li>
-              <span :class="[$style.fzMedium, $style.break, $style.mb10]">
-                {{ $t('平日（夜間）') }}
-              </span>
-              {{ $t('午後5時から翌朝午前9時') }}
-            </li>
-            <li>
-              <span :class="$style.fzMedium">
-                {{ $t('土日祝 終日') }}
-              </span>
-            </li>
-          </ul>
-        </dt>
-        <dd>
-          <div :class="[$style.phone, $style.fzNumeric]">
-            <span :class="$style.icon">
-              <PhoneIcon alt="Phone" />
-            </span>
-            <a href="tel:0353204592">03-5320-4592</a>
-          </div>
-          <div
-            v-if="!['ja', 'ja-basic'].includes($i18n.locale)"
-            :class="[$style.phone, $style.fzNumeric]"
-          >
-            <span :class="[$style.fzMedium, $style.break, $style.mb10]">
-              {{ $t('ひまわり') }}
-            </span>
-          </div>
-        </dd>
-      </div>
-    </dl>
+    <div :class="[$style.phone, $style.fzNumeric]">
+      <span :class="$style.icon">
+        <PhoneIcon alt="Phone" />
+      </span>
+      <a href="tel:0783226829">078-322-6829</a>
+    </div>
   </div>
 </template>
 

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -21,16 +21,16 @@
 
     <div :class="$style.callcenter">
       <p :class="$style.fzLarge">
-        {{ $t('新型コロナコールセンター') }}
+        {{ $t('新型コロナ専用健康相談窓口') }}
       </p>
       <p :class="$style.open">
-        {{ $t('午前9時から午後9時（土日祝含む）') }}
+        {{ $t('24時間対応（土日祝含む）') }}
       </p>
       <p :class="[$style.phone, $style.fzNumeric]">
         <span :class="$style.icon">
           <PhoneIcon alt="Phone" />
         </span>
-        <a href="tel:0570550571">0570-550571</a>
+        <a href="tel:0783226250">078-322-6250</a>
       </p>
     </div>
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #35

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「新型コロナコールセンター」を「新型コロナ専用健康相談窓口」に変更
- 「新型コロナ専用健康相談窓口」「帰国者・接触者 電話相談センター」の電話番号を変更

## 📸 スクリーンショット / Screenshots
「帰国者・接触者 電話相談センター」が24時間対応という扱いになった影響で、PC版表示で一部空きができてしまっています。
![image](https://user-images.githubusercontent.com/34566290/78045703-3becc600-73b1-11ea-91e4-77182a9900ae.png)

@kaizumaki お手数おかけしますが、空きスペース・矢印の向きなどはどうしたらよいかご教示いただけますか？（別PR対応でも大丈夫です）
