### PR TITLE
flowページを修正

### DIFF
--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -2,13 +2,8 @@
   <div :class="$style.Advisory">
     <div :class="$style.AdvisoryContainer">
       <div :class="$style.AdvisoryContents">
-        <div>
-          <span :class="$style.AdvisoryContentsTitle">{{
-            $t('新型コロナ受診相談窓口（日本語のみ）')
-          }}</span>
-        </div>
-        <div :class="[$style.AdvisoryContentsColsSentense, 'mt-4']">
-          {{ $t('帰国者・接触者 電話相談センター') }}
+        <div :class="[$style.AdvisoryContentsTitle, 'mt-4']">
+          {{ $t('帰国者・接触者 相談センター') }}
         </div>
         <div>
           <div :class="[$style.AdvisoryBoxContainer, $style.AdvisoryWhiteBox]">
@@ -52,7 +47,7 @@
     border: 3px solid #4d4d4d;
     border-radius: 4px;
     height: 100%;
-    padding: 30px 20px 20px 20px;
+    padding: 30px 12px 20px 12px;
     margin-bottom: 10px;
     text-align: center;
   }
@@ -65,7 +60,7 @@
     }
 
     &Title {
-      font-size: 26px;
+      font-size: 21px;
       line-height: 28px;
     }
 
@@ -75,10 +70,6 @@
 
     &SubTitle {
       font-size: 18px;
-    }
-
-    &ColsSentense {
-      line-height: 18px;
     }
   }
 

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="$style.flowContainer">
     <h3 :class="$style.sectionTitle">
-      <i18n path="新型コロナ外来 {advice} と判断された場合" tag="p">
+      <i18n path="帰国者・接触者外来 {advice} と判断された場合" tag="p">
         <template v-slot:advice>
           <strong>
             {{ $t('受診が不要') }}

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -36,7 +36,7 @@
             <span>{{ $t('症状が良くならない場合は') }}</span>
           </template>
           <template v-slot:advisory>
-            <strong>{{ $t('新型コロナ受診相談窓口（日本語のみ）') }}</strong>
+            <strong>{{ $t('帰国者・接触者 相談センター') }}</strong>
           </template>
         </i18n>
       </div>

--- a/components/flow/FlowPcPcr.vue
+++ b/components/flow/FlowPcPcr.vue
@@ -7,7 +7,7 @@
           <span :class="$style.small">{{ $t('※') }}</span>
         </p>
         <p :class="$style.content">
-          {{ $t('神戸市健康安全研究センター等') }}
+          {{ $t('神戸市環境保健研究所等') }}
         </p>
       </div>
     </div>

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -4,7 +4,7 @@
       <i18n
         :class="$style.Catch"
         tag="p"
-        path="新型コロナ外来 {advice} と判断された場合"
+        path="帰国者・接触者外来 {advice} と判断された場合"
       >
         <template v-slot:advice>
           <span :class="$style.Emphasis">
@@ -17,7 +17,7 @@
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
         <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
           <p :class="$style.Outpatient">
-            {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
+            {{ $t('帰国者・接触者外来') }}
           </p>
           <p :class="$style.Judge">
             {{ $t('医師による判断') }}

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -79,7 +79,7 @@
         <!-- eslint-enable -->
       </span>
       <span :class="$style.break">
-        {{ $t('神戸市健康安全研究センター等') }}
+        {{ $t('神戸市環境保健研究所等') }}
       </span>
       <small :class="[$style.note, $style.fzSmall, $style.break]">
         {{

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -148,7 +148,7 @@
             </template>
             <template v-slot:advisory>
               <strong :class="$style.advisory">
-                {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
+                {{ $t('帰国者・接触者 相談センター') }}
               </strong>
             </template>
           </i18n>

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -10,7 +10,7 @@
     <i18n
       tag="p"
       :class="$style.diag"
-      path="新型コロナ外来 {advice} と判断された場合"
+      path="帰国者・接触者外来 {advice} と判断された場合"
     >
       <template v-slot:advice>
         <span :class="[$style.fzXLLarge, $style.break]">
@@ -21,7 +21,7 @@
     <p :class="$style.decision">
       <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
         <span :class="$style.fzSmall">
-          {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
+          {{ $t('帰国者・接触者外来') }}
         </span>
         <span :class="[$style.fzLarge, $style.break]">{{
           $t('医師による判断')
@@ -119,7 +119,7 @@
       id="not_required"
       tag="p"
       :class="[$style.diag, $style.hr]"
-      path="新型コロナ外来 {advice} と判断された場合"
+      path="帰国者・接触者外来 {advice} と判断された場合"
     >
       <template v-slot:advice>
         <span :class="[$style.break, $style.fzXLLarge]">

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -144,9 +144,7 @@
         <p>
           <i18n path="{getWorse}{advisory}に相談">
             <template v-slot:getWorse>
-              <i18n path="症状が良くならない場合は">
-                <span>{{ $t('症状が良くならない場合は') }}</span>
-              </i18n>
+              <span>{{ $t('症状が良くならない場合は') }}</span>
             </template>
             <template v-slot:advisory>
               <strong :class="$style.advisory">

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -79,7 +79,9 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <span :class="$style.text">{{
+        $t('帰国者・接触者 相談センターへ')
+      }}</span>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -61,7 +61,9 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <span :class="$style.text">{{
+        $t('帰国者・接触者 相談センターへ')
+      }}</span>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -124,7 +124,9 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <span :class="$style.text">{{
+        $t('帰国者・接触者 相談センターへ')
+      }}</span>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -16,17 +16,6 @@
             {{ $t('対策サイト') }}
           </h1>
         </div>
-        <div class="PrintMeta-QRWrapper">
-          <div class="PrintMeta-QR flex-shrink-0" flat tile color="transparent">
-            <img src="/site-qr.svg" :alt="$t('2次元コード')" />
-          </div>
-          <div class="flex-shrink-0" flat tile color="transparent">
-            <p class="PrintMeta-Text">
-              {{ $t('※最新の情報はWebページをご覧ください') }}
-            </p>
-            <p class="PrintMeta-Link">https://stopcovid19.metro.tokyo.lg.jp/</p>
-          </div>
-        </div>
       </div>
       <nuxt />
     </div>


### PR DESCRIPTION
## ⛏ 変更内容 / Details of Changes
- 印刷用ページで二次元バーコードなどを削除
- 「新型コロナ受診相談窓口」を「帰国者・接触者 相談センター」に変更
- 「新型コロナ外来」を「帰国者・接触者外来」に変更
- 「神戸市健康安全研究センター等」を「神戸市環境保健研究所等」に変更

close #52 