### PR TITLE
メタタグを神戸市仕様に変更

### DIFF
--- a/components/DevelopmentModeMark.vue
+++ b/components/DevelopmentModeMark.vue
@@ -2,7 +2,7 @@
   <div v-if="isDevelopmentMode" class="DevelopmentModeMark">
     開発中（development mode）
     <a
-      href="https://stopcovid19.metro.tokyo.lg.jp/"
+      href="https://kobe.stopcovid19.jp/"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://kobe.stopcovid19.jp${this.$route.path}`
         },
         {
           rel: 'stylesheet',
@@ -133,7 +133,7 @@ export default Vue.extend({
         {
           hid: 'og:url',
           property: 'og:url',
-          content: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          content: `https://kobe.stopcovid19.jp${this.$route.path}`
         },
         ogLocale,
         {

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -59,7 +59,7 @@ export default Vue.extend({
       link: [
         {
           rel: 'canonical',
-          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+          href: `https://kobe.stopcovid19.jp${this.$route.path}`
         }
       ]
     }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,7 +23,7 @@ const config: Configuration = {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://stopcovid19.metro.tokyo.lg.jp'
+        content: 'https://kobe.stopcovid19.jp/'
       },
       {
         hid: 'twitter:card',
@@ -33,12 +33,12 @@ const config: Configuration = {
       {
         hid: 'twitter:site',
         name: 'twitter:site',
-        content: '@tokyo_bousai'
+        content: '@kobekoho'
       },
       {
         hid: 'twitter:creator',
         name: 'twitter:creator',
-        content: '@tokyo_bousai'
+        content: '@kobekoho'
       },
       {
         hid: 'fb:app_id',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #58 

## ⛏ 変更内容 / Details of Changes
- メタタグを神戸市仕様に変更
  - `fb:app_id` は保留
- 開発版サイトの注意表示（本番環境では非表示）内のリンクを神戸市版に変更