### PR TITLE
Facebook App IDを東京版ではないものに変更

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -43,7 +43,7 @@ const config: Configuration = {
       {
         hid: 'fb:app_id',
         property: 'fb:app_id',
-        content: '2879625188795443'
+        content: '2677592302516731' // @todo 正式なものに差し替える
       },
       {
         hid: 'note:card',


### PR DESCRIPTION
**NOTE:** 後で正式なものに差し替える